### PR TITLE
Refactor: Implement Tool Registry System for MCP Server

### DIFF
--- a/check_syntax.py
+++ b/check_syntax.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Syntax checker script for the notes-agent project
+Compiles all Python files to check for syntax errors
+"""
+
+import py_compile
+import sys
+from pathlib import Path
+
+def check_file_syntax(file_path: Path) -> bool:
+    """Check syntax of a single Python file"""
+    try:
+        py_compile.compile(file_path, doraise=True)
+        print(f"✅ {file_path}")
+        return True
+    except py_compile.PyCompileError as e:
+        print(f"❌ {file_path}: {e}")
+        return False
+
+def main():
+    """Check syntax of all Python files in the project"""
+    project_root = Path(__file__).parent
+    python_files = list(project_root.glob("*.py"))
+    
+    print("Checking syntax of Python files...")
+    print("-" * 40)
+    
+    failed_files = []
+    for file_path in python_files:
+        if not check_file_syntax(file_path):
+            failed_files.append(file_path)
+    
+    print("-" * 40)
+    if failed_files:
+        print(f"❌ {len(failed_files)} files failed syntax check:")
+        for file_path in failed_files:
+            print(f"  - {file_path}")
+        sys.exit(1)
+    else:
+        print(f"✅ All {len(python_files)} Python files passed syntax check")
+
+if __name__ == "__main__":
+    main()

--- a/handlers.py
+++ b/handlers.py
@@ -3,68 +3,66 @@ Individual Tool Handlers for MCP Server
 Each handler implements a specific tool functionality
 """
 
-from typing import Dict, Any
-from mcp.types import CallToolResult, Tool
+from typing import Dict, Any, List
+from mcp.types import Tool, TextContent
 from tool_handlers import BaseToolHandler
 from config import SERVER_NAME, SERVER_VERSION, RAW_DIR, PROCESSED_DIR, INDEX_DIR
 
 
 class ListRawFilesHandler(BaseToolHandler):
     """Handler for listing raw files"""
-    
-    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+
+    async def execute(self, arguments: Dict[str, Any]) -> List[TextContent]:
         raw_files = self.storage.get_raw_files()
         file_list = [f.name for f in raw_files]
-        text = f"Found {len(file_list)} raw files:\n" + "\n".join(f"• {f}" for f in file_list)
+        text = f"Found {len(file_list)} raw files:\n" + "\n".join(
+            f"• {f}" for f in file_list
+        )
         return self.create_text_response(text)
-    
+
     def get_tool_definition(self) -> Tool:
         return Tool(
             name="list_raw_files",
             description="List all raw handwritten text files available for processing",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
+            inputSchema={"type": "object", "properties": {}, "required": []},
         )
 
 
 class ListProcessedFilesHandler(BaseToolHandler):
     """Handler for listing processed files"""
-    
-    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+
+    async def execute(self, arguments: Dict[str, Any]) -> List[TextContent]:
         processed_files = self.storage.get_processed_files()
         file_list = [f.name for f in processed_files]
-        text = f"Found {len(file_list)} processed files:\n" + "\n".join(f"• {f}" for f in file_list)
+        text = f"Found {len(file_list)} processed files:\n" + "\n".join(
+            f"• {f}" for f in file_list
+        )
         return self.create_text_response(text)
-    
+
     def get_tool_definition(self) -> Tool:
         return Tool(
             name="list_processed_files",
             description="List all processed and cleaned text files",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
+            inputSchema={"type": "object", "properties": {}, "required": []},
         )
 
 
 class ReadRawFileHandler(BaseToolHandler):
     """Handler for reading raw files"""
-    
-    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+
+    async def execute(self, arguments: Dict[str, Any]) -> List[TextContent]:
         if error := self.validate_required_args(arguments, ["filename"]):
             return self.create_text_response(error)
-        
+
         filename = arguments["filename"]
         content = self.storage.read_raw_file(filename)
         if content is None:
-            return self.create_text_response(f"Error: Could not read file '{filename}' or file does not exist")
-        
+            return self.create_text_response(
+                f"Error: Could not read file '{filename}' or file does not exist"
+            )
+
         return self.create_text_response(f"Content of '{filename}':\n\n{content}")
-    
+
     def get_tool_definition(self) -> Tool:
         return Tool(
             name="read_raw_file",
@@ -74,28 +72,32 @@ class ReadRawFileHandler(BaseToolHandler):
                 "properties": {
                     "filename": {
                         "type": "string",
-                        "description": "Name of the file to read"
+                        "description": "Name of the file to read",
                     }
                 },
-                "required": ["filename"]
-            }
+                "required": ["filename"],
+            },
         )
 
 
 class ReadProcessedFileHandler(BaseToolHandler):
     """Handler for reading processed files"""
-    
-    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+
+    async def execute(self, arguments: Dict[str, Any]) -> List[TextContent]:
         if error := self.validate_required_args(arguments, ["filename"]):
             return self.create_text_response(error)
-        
+
         filename = arguments["filename"]
         content = self.storage.read_processed_file(filename)
         if content is None:
-            return self.create_text_response(f"Error: Could not read processed file '{filename}' or file does not exist")
-        
-        return self.create_text_response(f"Content of processed '{filename}':\n\n{content}")
-    
+            return self.create_text_response(
+                f"Error: Could not read processed file '{filename}' or file does not exist"
+            )
+
+        return self.create_text_response(
+            f"Content of processed '{filename}':\n\n{content}"
+        )
+
     def get_tool_definition(self) -> Tool:
         return Tool(
             name="read_processed_file",
@@ -105,32 +107,32 @@ class ReadProcessedFileHandler(BaseToolHandler):
                 "properties": {
                     "filename": {
                         "type": "string",
-                        "description": "Name of the processed file to read"
+                        "description": "Name of the processed file to read",
                     }
                 },
-                "required": ["filename"]
-            }
+                "required": ["filename"],
+            },
         )
 
 
 class GetDocumentInfoHandler(BaseToolHandler):
     """Handler for getting document metadata"""
-    
-    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+
+    async def execute(self, arguments: Dict[str, Any]) -> List[TextContent]:
         if error := self.validate_required_args(arguments, ["filename"]):
             return self.create_text_response(error)
-        
+
         filename = arguments["filename"]
         info = self.storage.get_document_info(filename)
         if info is None:
             return self.create_text_response(f"No metadata found for '{filename}'")
-        
+
         info_text = f"Document Information for '{filename}':\n\n"
         for key, value in info.items():
             info_text += f"• {key}: {value}\n"
-        
+
         return self.create_text_response(info_text)
-    
+
     def get_tool_definition(self) -> Tool:
         return Tool(
             name="get_document_info",
@@ -140,77 +142,73 @@ class GetDocumentInfoHandler(BaseToolHandler):
                 "properties": {
                     "filename": {
                         "type": "string",
-                        "description": "Name of the document to get info for"
+                        "description": "Name of the document to get info for",
                     }
                 },
-                "required": ["filename"]
-            }
+                "required": ["filename"],
+            },
         )
 
 
 class ListAllDocumentsHandler(BaseToolHandler):
     """Handler for listing all documents with metadata"""
-    
-    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+
+    async def execute(self, arguments: Dict[str, Any]) -> List[TextContent]:
         all_docs = self.storage.list_all_documents()
-        
+
         if not all_docs:
             return self.create_text_response("No documents found in the system")
-        
+
         result_text = f"All Documents ({len(all_docs)} total):\n\n"
         for filename, info in all_docs.items():
             result_text += f"📄 {filename}\n"
             result_text += f"   Processed: {info.get('processed_at', 'Unknown')}\n"
             result_text += f"   Size: {info.get('size', 0)} bytes\n"
             result_text += f"   Hash: {info.get('hash', 'Unknown')[:8]}...\n\n"
-        
+
         return self.create_text_response(result_text)
-    
+
     def get_tool_definition(self) -> Tool:
         return Tool(
             name="list_all_documents",
             description="List all documents with their metadata and processing status",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
+            inputSchema={"type": "object", "properties": {}, "required": []},
         )
 
 
 class CheckFilesNeedingProcessingHandler(BaseToolHandler):
     """Handler for checking which files need processing"""
-    
-    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+
+    async def execute(self, arguments: Dict[str, Any]) -> List[TextContent]:
         files_needing_processing = self.storage.get_files_needing_processing()
-        
+
         if not files_needing_processing:
-            return self.create_text_response("✅ All files are up to date - no processing needed")
-        
+            return self.create_text_response(
+                "✅ All files are up to date - no processing needed"
+            )
+
         file_list = [f.name for f in files_needing_processing]
-        text = f"📋 Found {len(file_list)} files needing processing:\n" + "\n".join(f"• {f}" for f in file_list)
+        text = f"📋 Found {len(file_list)} files needing processing:\n" + "\n".join(
+            f"• {f}" for f in file_list
+        )
         return self.create_text_response(text)
-    
+
     def get_tool_definition(self) -> Tool:
         return Tool(
             name="check_files_needing_processing",
             description="Check which files need processing (new or changed files)",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
+            inputSchema={"type": "object", "properties": {}, "required": []},
         )
 
 
 class GetServerStatusHandler(BaseToolHandler):
     """Handler for getting server status"""
-    
-    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+
+    async def execute(self, arguments: Dict[str, Any]) -> List[TextContent]:
         raw_files = len(self.storage.get_raw_files())
         processed_files = len(self.storage.get_processed_files())
         files_needing_processing = len(self.storage.get_files_needing_processing())
-        
+
         status_text = f"""🔧 Handwritten Notes MCP Server Status
         
 Server: {SERVER_NAME} v{SERVER_VERSION}
@@ -224,32 +222,28 @@ Directory Structure:
 • Index Files: {INDEX_DIR}
 
 Status: ✅ Ready for Phase 2 development"""
-        
+
         return self.create_text_response(status_text)
-    
+
     def get_tool_definition(self) -> Tool:
         return Tool(
             name="get_server_status",
             description="Get the current status of the MCP server and storage system",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
+            inputSchema={"type": "object", "properties": {}, "required": []},
         )
 
 
 class ProcessRawFileHandler(BaseToolHandler):
     """Handler for processing raw files"""
-    
-    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+
+    async def execute(self, arguments: Dict[str, Any]) -> List[TextContent]:
         if error := self.validate_required_args(arguments, ["filename"]):
             return self.create_text_response(error)
-        
+
         filename = arguments["filename"]
         result = await self.storage.process_raw_file(filename)
         return self.create_text_response(result)
-    
+
     def get_tool_definition(self) -> Tool:
         return Tool(
             name="process_raw_file",
@@ -259,9 +253,9 @@ class ProcessRawFileHandler(BaseToolHandler):
                 "properties": {
                     "filename": {
                         "type": "string",
-                        "description": "Name of the raw file to process"
+                        "description": "Name of the raw file to process",
                     }
                 },
-                "required": ["filename"]
-            }
+                "required": ["filename"],
+            },
         )

--- a/handlers.py
+++ b/handlers.py
@@ -1,0 +1,267 @@
+"""
+Individual Tool Handlers for MCP Server
+Each handler implements a specific tool functionality
+"""
+
+from typing import Dict, Any
+from mcp.types import CallToolResult, Tool
+from tool_handlers import BaseToolHandler
+from config import SERVER_NAME, SERVER_VERSION, RAW_DIR, PROCESSED_DIR, INDEX_DIR
+
+
+class ListRawFilesHandler(BaseToolHandler):
+    """Handler for listing raw files"""
+    
+    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+        raw_files = self.storage.get_raw_files()
+        file_list = [f.name for f in raw_files]
+        text = f"Found {len(file_list)} raw files:\n" + "\n".join(f"• {f}" for f in file_list)
+        return self.create_text_response(text)
+    
+    def get_tool_definition(self) -> Tool:
+        return Tool(
+            name="list_raw_files",
+            description="List all raw handwritten text files available for processing",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        )
+
+
+class ListProcessedFilesHandler(BaseToolHandler):
+    """Handler for listing processed files"""
+    
+    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+        processed_files = self.storage.get_processed_files()
+        file_list = [f.name for f in processed_files]
+        text = f"Found {len(file_list)} processed files:\n" + "\n".join(f"• {f}" for f in file_list)
+        return self.create_text_response(text)
+    
+    def get_tool_definition(self) -> Tool:
+        return Tool(
+            name="list_processed_files",
+            description="List all processed and cleaned text files",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        )
+
+
+class ReadRawFileHandler(BaseToolHandler):
+    """Handler for reading raw files"""
+    
+    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+        if error := self.validate_required_args(arguments, ["filename"]):
+            return self.create_text_response(error)
+        
+        filename = arguments["filename"]
+        content = self.storage.read_raw_file(filename)
+        if content is None:
+            return self.create_text_response(f"Error: Could not read file '{filename}' or file does not exist")
+        
+        return self.create_text_response(f"Content of '{filename}':\n\n{content}")
+    
+    def get_tool_definition(self) -> Tool:
+        return Tool(
+            name="read_raw_file",
+            description="Read the content of a raw handwritten text file",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "filename": {
+                        "type": "string",
+                        "description": "Name of the file to read"
+                    }
+                },
+                "required": ["filename"]
+            }
+        )
+
+
+class ReadProcessedFileHandler(BaseToolHandler):
+    """Handler for reading processed files"""
+    
+    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+        if error := self.validate_required_args(arguments, ["filename"]):
+            return self.create_text_response(error)
+        
+        filename = arguments["filename"]
+        content = self.storage.read_processed_file(filename)
+        if content is None:
+            return self.create_text_response(f"Error: Could not read processed file '{filename}' or file does not exist")
+        
+        return self.create_text_response(f"Content of processed '{filename}':\n\n{content}")
+    
+    def get_tool_definition(self) -> Tool:
+        return Tool(
+            name="read_processed_file",
+            description="Read the content of a processed/cleaned text file",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "filename": {
+                        "type": "string",
+                        "description": "Name of the processed file to read"
+                    }
+                },
+                "required": ["filename"]
+            }
+        )
+
+
+class GetDocumentInfoHandler(BaseToolHandler):
+    """Handler for getting document metadata"""
+    
+    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+        if error := self.validate_required_args(arguments, ["filename"]):
+            return self.create_text_response(error)
+        
+        filename = arguments["filename"]
+        info = self.storage.get_document_info(filename)
+        if info is None:
+            return self.create_text_response(f"No metadata found for '{filename}'")
+        
+        info_text = f"Document Information for '{filename}':\n\n"
+        for key, value in info.items():
+            info_text += f"• {key}: {value}\n"
+        
+        return self.create_text_response(info_text)
+    
+    def get_tool_definition(self) -> Tool:
+        return Tool(
+            name="get_document_info",
+            description="Get metadata and processing information for a specific document",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "filename": {
+                        "type": "string",
+                        "description": "Name of the document to get info for"
+                    }
+                },
+                "required": ["filename"]
+            }
+        )
+
+
+class ListAllDocumentsHandler(BaseToolHandler):
+    """Handler for listing all documents with metadata"""
+    
+    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+        all_docs = self.storage.list_all_documents()
+        
+        if not all_docs:
+            return self.create_text_response("No documents found in the system")
+        
+        result_text = f"All Documents ({len(all_docs)} total):\n\n"
+        for filename, info in all_docs.items():
+            result_text += f"📄 {filename}\n"
+            result_text += f"   Processed: {info.get('processed_at', 'Unknown')}\n"
+            result_text += f"   Size: {info.get('size', 0)} bytes\n"
+            result_text += f"   Hash: {info.get('hash', 'Unknown')[:8]}...\n\n"
+        
+        return self.create_text_response(result_text)
+    
+    def get_tool_definition(self) -> Tool:
+        return Tool(
+            name="list_all_documents",
+            description="List all documents with their metadata and processing status",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        )
+
+
+class CheckFilesNeedingProcessingHandler(BaseToolHandler):
+    """Handler for checking which files need processing"""
+    
+    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+        files_needing_processing = self.storage.get_files_needing_processing()
+        
+        if not files_needing_processing:
+            return self.create_text_response("✅ All files are up to date - no processing needed")
+        
+        file_list = [f.name for f in files_needing_processing]
+        text = f"📋 Found {len(file_list)} files needing processing:\n" + "\n".join(f"• {f}" for f in file_list)
+        return self.create_text_response(text)
+    
+    def get_tool_definition(self) -> Tool:
+        return Tool(
+            name="check_files_needing_processing",
+            description="Check which files need processing (new or changed files)",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        )
+
+
+class GetServerStatusHandler(BaseToolHandler):
+    """Handler for getting server status"""
+    
+    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+        raw_files = len(self.storage.get_raw_files())
+        processed_files = len(self.storage.get_processed_files())
+        files_needing_processing = len(self.storage.get_files_needing_processing())
+        
+        status_text = f"""🔧 Handwritten Notes MCP Server Status
+        
+Server: {SERVER_NAME} v{SERVER_VERSION}
+Raw Files: {raw_files}
+Processed Files: {processed_files}
+Files Needing Processing: {files_needing_processing}
+
+Directory Structure:
+• Raw Files: {RAW_DIR}
+• Processed Files: {PROCESSED_DIR}
+• Index Files: {INDEX_DIR}
+
+Status: ✅ Ready for Phase 2 development"""
+        
+        return self.create_text_response(status_text)
+    
+    def get_tool_definition(self) -> Tool:
+        return Tool(
+            name="get_server_status",
+            description="Get the current status of the MCP server and storage system",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        )
+
+
+class ProcessRawFileHandler(BaseToolHandler):
+    """Handler for processing raw files"""
+    
+    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+        if error := self.validate_required_args(arguments, ["filename"]):
+            return self.create_text_response(error)
+        
+        filename = arguments["filename"]
+        result = await self.storage.process_raw_file(filename)
+        return self.create_text_response(result)
+    
+    def get_tool_definition(self) -> Tool:
+        return Tool(
+            name="process_raw_file",
+            description="Process a raw handwritten text file through LLM to improve formatting, fix typos, and correct OCR errors",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "filename": {
+                        "type": "string",
+                        "description": "Name of the raw file to process"
+                    }
+                },
+                "required": ["filename"]
+            }
+        )

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 """
 Handwritten Notes MCP Server - Phase 1
-Basic file operations and MCP server setup
+Basic file operations and MCP server setup with Tool Registry system
 """
 
 import asyncio
@@ -27,6 +27,18 @@ from config import (
     LOG_LEVEL
 )
 from storage import DocumentStorage
+from tool_handlers import tool_registry
+from handlers import (
+    ListRawFilesHandler,
+    ListProcessedFilesHandler,
+    ReadRawFileHandler,
+    ReadProcessedFileHandler,
+    GetDocumentInfoHandler,
+    ListAllDocumentsHandler,
+    CheckFilesNeedingProcessingHandler,
+    GetServerStatusHandler,
+    ProcessRawFileHandler,
+)
 
 # Configure logging
 logger.remove()
@@ -39,291 +51,36 @@ server = Server(SERVER_NAME)
 # Initialize storage
 storage = DocumentStorage()
 
+# Register all tool handlers
+def register_tool_handlers():
+    """Register all tool handlers with the tool registry"""
+    handlers = [
+        ("list_raw_files", ListRawFilesHandler(storage)),
+        ("list_processed_files", ListProcessedFilesHandler(storage)),
+        ("read_raw_file", ReadRawFileHandler(storage)),
+        ("read_processed_file", ReadProcessedFileHandler(storage)),
+        ("get_document_info", GetDocumentInfoHandler(storage)),
+        ("list_all_documents", ListAllDocumentsHandler(storage)),
+        ("check_files_needing_processing", CheckFilesNeedingProcessingHandler(storage)),
+        ("get_server_status", GetServerStatusHandler(storage)),
+        ("process_raw_file", ProcessRawFileHandler(storage)),
+    ]
+    
+    for name, handler in handlers:
+        tool_registry.register(name, handler)
+
+# Register handlers on import
+register_tool_handlers()
+
 @server.list_tools()
 async def list_tools() -> List[Tool]:
     """List available tools for the MCP server"""
-    return [
-        Tool(
-            name="list_raw_files",
-            description="List all raw handwritten text files available for processing",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
-        ),
-        Tool(
-            name="list_processed_files",
-            description="List all processed and cleaned text files",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
-        ),
-        Tool(
-            name="read_raw_file",
-            description="Read the content of a raw handwritten text file",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "filename": {
-                        "type": "string",
-                        "description": "Name of the file to read"
-                    }
-                },
-                "required": ["filename"]
-            }
-        ),
-        Tool(
-            name="read_processed_file",
-            description="Read the content of a processed/cleaned text file",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "filename": {
-                        "type": "string",
-                        "description": "Name of the processed file to read"
-                    }
-                },
-                "required": ["filename"]
-            }
-        ),
-        Tool(
-            name="get_document_info",
-            description="Get metadata and processing information for a specific document",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "filename": {
-                        "type": "string",
-                        "description": "Name of the document to get info for"
-                    }
-                },
-                "required": ["filename"]
-            }
-        ),
-        Tool(
-            name="list_all_documents",
-            description="List all documents with their metadata and processing status",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
-        ),
-        Tool(
-            name="check_files_needing_processing",
-            description="Check which files need processing (new or changed files)",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
-        ),
-        Tool(
-            name="get_server_status",
-            description="Get the current status of the MCP server and storage system",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": []
-            }
-        ),
-        Tool(
-            name="process_raw_file",
-            description="Process a raw handwritten text file through LLM to improve formatting, fix typos, and correct OCR errors",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "filename": {
-                        "type": "string",
-                        "description": "Name of the raw file to process"
-                    }
-                },
-                "required": ["filename"]
-            }
-        )
-    ]
+    return tool_registry.get_tool_definitions()
 
 @server.call_tool()
 async def call_tool(name: str, arguments: Dict[str, Any]) -> CallToolResult:
-    """Handle tool calls from Claude Desktop"""
-    
-    try:
-        if name == "list_raw_files":
-            raw_files = storage.get_raw_files()
-            file_list = [f.name for f in raw_files]
-            
-            return CallToolResult(
-                content=[
-                    TextContent(
-                        type="text",
-                        text=f"Found {len(file_list)} raw files:\n" + "\n".join(f"• {f}" for f in file_list)
-                    )
-                ]
-            )
-        
-        elif name == "list_processed_files":
-            processed_files = storage.get_processed_files()
-            file_list = [f.name for f in processed_files]
-            
-            return CallToolResult(
-                content=[
-                    TextContent(
-                        type="text",
-                        text=f"Found {len(file_list)} processed files:\n" + "\n".join(f"• {f}" for f in file_list)
-                    )
-                ]
-            )
-        
-        elif name == "read_raw_file":
-            filename = arguments.get("filename")
-            if not filename:
-                return CallToolResult(
-                    content=[TextContent(type="text", text="Error: filename is required")]
-                )
-            
-            content = storage.read_raw_file(filename)
-            if content is None:
-                return CallToolResult(
-                    content=[TextContent(type="text", text=f"Error: Could not read file '{filename}' or file does not exist")]
-                )
-            
-            return CallToolResult(
-                content=[
-                    TextContent(
-                        type="text",
-                        text=f"Content of '{filename}':\n\n{content}"
-                    )
-                ]
-            )
-        
-        elif name == "read_processed_file":
-            filename = arguments.get("filename")
-            if not filename:
-                return CallToolResult(
-                    content=[TextContent(type="text", text="Error: filename is required")]
-                )
-            
-            content = storage.read_processed_file(filename)
-            if content is None:
-                return CallToolResult(
-                    content=[TextContent(type="text", text=f"Error: Could not read processed file '{filename}' or file does not exist")]
-                )
-            
-            return CallToolResult(
-                content=[
-                    TextContent(
-                        type="text",
-                        text=f"Content of processed '{filename}':\n\n{content}"
-                    )
-                ]
-            )
-        
-        elif name == "get_document_info":
-            filename = arguments.get("filename")
-            if not filename:
-                return CallToolResult(
-                    content=[TextContent(type="text", text="Error: filename is required")]
-                )
-            
-            info = storage.get_document_info(filename)
-            if info is None:
-                return CallToolResult(
-                    content=[TextContent(type="text", text=f"No metadata found for '{filename}'")]
-                )
-            
-            info_text = f"Document Information for '{filename}':\n\n"
-            for key, value in info.items():
-                info_text += f"• {key}: {value}\n"
-            
-            return CallToolResult(
-                content=[TextContent(type="text", text=info_text)]
-            )
-        
-        elif name == "list_all_documents":
-            all_docs = storage.list_all_documents()
-            
-            if not all_docs:
-                return CallToolResult(
-                    content=[TextContent(type="text", text="No documents found in the system")]
-                )
-            
-            result_text = f"All Documents ({len(all_docs)} total):\n\n"
-            for filename, info in all_docs.items():
-                result_text += f"📄 {filename}\n"
-                result_text += f"   Processed: {info.get('processed_at', 'Unknown')}\n"
-                result_text += f"   Size: {info.get('size', 0)} bytes\n"
-                result_text += f"   Hash: {info.get('hash', 'Unknown')[:8]}...\n\n"
-            
-            return CallToolResult(
-                content=[TextContent(type="text", text=result_text)]
-            )
-        
-        elif name == "check_files_needing_processing":
-            files_needing_processing = storage.get_files_needing_processing()
-            
-            if not files_needing_processing:
-                return CallToolResult(
-                    content=[TextContent(type="text", text="✅ All files are up to date - no processing needed")]
-                )
-            
-            file_list = [f.name for f in files_needing_processing]
-            return CallToolResult(
-                content=[
-                    TextContent(
-                        type="text",
-                        text=f"📋 Found {len(file_list)} files needing processing:\n" + "\n".join(f"• {f}" for f in file_list)
-                    )
-                ]
-            )
-        
-        elif name == "get_server_status":
-            raw_files = len(storage.get_raw_files())
-            processed_files = len(storage.get_processed_files())
-            files_needing_processing = len(storage.get_files_needing_processing())
-            
-            status_text = f"""🔧 Handwritten Notes MCP Server Status
-            
-Server: {SERVER_NAME} v{SERVER_VERSION}
-Raw Files: {raw_files}
-Processed Files: {processed_files}
-Files Needing Processing: {files_needing_processing}
-
-Directory Structure:
-• Raw Files: {RAW_DIR}
-• Processed Files: {PROCESSED_DIR}
-• Index Files: {INDEX_DIR}
-
-Status: ✅ Ready for Phase 2 development"""
-            
-            return CallToolResult(
-                content=[TextContent(type="text", text=status_text)]
-            )
-        
-        elif name == "process_raw_file":
-            filename = arguments.get("filename")
-            if not filename:
-                return CallToolResult(
-                    content=[TextContent(type="text", text="Error: filename is required")]
-                )
-            
-            result = await storage.process_raw_file(filename)
-            return CallToolResult(
-                content=[TextContent(type="text", text=result)]
-            )
-        
-        else:
-            return CallToolResult(
-                content=[TextContent(type="text", text=f"Unknown tool: {name}")]
-            )
-    
-    except Exception as e:
-        logger.error(f"Error in tool call {name}: {e}")
-        return CallToolResult(
-            content=[TextContent(type="text", text=f"Error executing {name}: {str(e)}")]
-        )
+    """Handle tool calls from Claude Desktop using the tool registry"""
+    return await tool_registry.execute_tool(name, arguments)
 
 async def main():
     """Main function to run the MCP server"""

--- a/server.py
+++ b/server.py
@@ -18,13 +18,13 @@ from mcp.types import (
 from loguru import logger
 
 from config import (
-    SERVER_NAME, 
-    SERVER_VERSION, 
-    RAW_DIR, 
-    PROCESSED_DIR, 
+    SERVER_NAME,
+    SERVER_VERSION,
+    RAW_DIR,
+    PROCESSED_DIR,
     INDEX_DIR,
     LOG_FILE,
-    LOG_LEVEL
+    LOG_LEVEL,
 )
 from storage import DocumentStorage
 from tool_handlers import tool_registry
@@ -51,6 +51,7 @@ server = Server(SERVER_NAME)
 # Initialize storage
 storage = DocumentStorage()
 
+
 # Register all tool handlers
 def register_tool_handlers():
     """Register all tool handlers with the tool registry"""
@@ -65,22 +66,26 @@ def register_tool_handlers():
         ("get_server_status", GetServerStatusHandler(storage)),
         ("process_raw_file", ProcessRawFileHandler(storage)),
     ]
-    
+
     for name, handler in handlers:
         tool_registry.register(name, handler)
 
+
 # Register handlers on import
 register_tool_handlers()
+
 
 @server.list_tools()
 async def list_tools() -> List[Tool]:
     """List available tools for the MCP server"""
     return tool_registry.get_tool_definitions()
 
+
 @server.call_tool()
-async def call_tool(name: str, arguments: Dict[str, Any]) -> CallToolResult:
+async def call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
     """Handle tool calls from Claude Desktop using the tool registry"""
     return await tool_registry.execute_tool(name, arguments)
+
 
 async def main():
     """Main function to run the MCP server"""
@@ -88,14 +93,15 @@ async def main():
     logger.info(f"Raw files directory: {RAW_DIR}")
     logger.info(f"Processed files directory: {PROCESSED_DIR}")
     logger.info(f"Index directory: {INDEX_DIR}")
-    
+
     # Ensure directories exist
     for directory in [RAW_DIR, PROCESSED_DIR, INDEX_DIR]:
         directory.mkdir(parents=True, exist_ok=True)
-    
+
     # Run the server
     async with stdio_server() as streams:
         await server.run(streams[0], streams[1], server.create_initialization_options())
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/tool_handlers.py
+++ b/tool_handlers.py
@@ -5,79 +5,83 @@ Provides a structured approach to managing tool handlers
 
 from abc import ABC, abstractmethod
 from typing import Dict, Any, List, Optional, Callable, Awaitable
-from mcp.types import CallToolResult, TextContent, Tool
+from mcp.types import TextContent, AudioContent, ImageContent, Tool
 from loguru import logger
 
 
 class BaseToolHandler(ABC):
     """Base class for all tool handlers with common functionality"""
-    
+
     def __init__(self, storage):
         self.storage = storage
-    
+
     @abstractmethod
-    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+    async def execute(
+        self, arguments: Dict[str, Any]
+    ) -> List[TextContent | ImageContent | AudioContent]:
         """Execute the tool with given arguments"""
         pass
-    
+
     @abstractmethod
     def get_tool_definition(self) -> Tool:
         """Return the tool definition for MCP server registration"""
         pass
-    
-    def validate_required_args(self, arguments: Dict[str, Any], required: List[str]) -> Optional[str]:
+
+    def validate_required_args(
+        self, arguments: Dict[str, Any], required: List[str]
+    ) -> Optional[str]:
         """Validate that required arguments are present and non-empty"""
         for arg in required:
             if not arguments.get(arg):
                 return f"Error: {arg} is required"
         return None
-    
-    def create_text_response(self, text: str) -> CallToolResult:
+
+    def create_text_response(self, text: str) -> List[TextContent]:
         """Create a standard text response"""
-        return CallToolResult(
-            content=[TextContent(type="text", text=text)]
-        )
+        return [TextContent(type="text", text=text)]
+
+    def create_image_response(self, audio: str) -> List[AudioContent]:
+        """Create a standard audio response"""
+        return [AudioContent(type="audio", data=audio)]
 
 
 class ToolRegistry:
     """Registry for managing tool handlers"""
-    
+
     def __init__(self):
         self._handlers: Dict[str, BaseToolHandler] = {}
-    
+
     def register(self, name: str, handler: BaseToolHandler):
         """Register a tool handler"""
         self._handlers[name] = handler
         logger.debug(f"Registered tool handler: {name}")
-    
+
     def get_handler(self, name: str) -> Optional[BaseToolHandler]:
         """Get a tool handler by name"""
         return self._handlers.get(name)
-    
+
     def list_tool_names(self) -> List[str]:
         """List all registered tool names"""
         return list(self._handlers.keys())
-    
+
     def get_tool_definitions(self) -> List[Tool]:
         """Get all tool definitions for MCP server registration"""
         return [handler.get_tool_definition() for handler in self._handlers.values()]
-    
-    async def execute_tool(self, name: str, arguments: Dict[str, Any]) -> CallToolResult:
+
+    async def execute_tool(
+        self, name: str, arguments: Dict[str, Any]
+    ) -> List[TextContent | ImageContent | AudioContent]:
         """Execute a tool by name with error handling"""
         try:
             handler = self.get_handler(name)
             if not handler:
-                return CallToolResult(
-                    content=[TextContent(type="text", text=f"Unknown tool: {name}")]
-                )
-            
+                return [TextContent(type="text", text=f"Unknown tool: {name}")]
+
             return await handler.execute(arguments)
-        
+
         except Exception as e:
             logger.error(f"Error in tool call {name}: {e}")
-            return CallToolResult(
-                content=[TextContent(type="text", text=f"Error executing {name}: {str(e)}")]
-            )
+            return [TextContent(type="text", text=f"Error executing {name}: {str(e)}")]
 
 
 # Global tool registry instance

--- a/tool_handlers.py
+++ b/tool_handlers.py
@@ -1,0 +1,84 @@
+"""
+Tool Registry and Base Handler Classes for MCP Server
+Provides a structured approach to managing tool handlers
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, Any, List, Optional, Callable, Awaitable
+from mcp.types import CallToolResult, TextContent, Tool
+from loguru import logger
+
+
+class BaseToolHandler(ABC):
+    """Base class for all tool handlers with common functionality"""
+    
+    def __init__(self, storage):
+        self.storage = storage
+    
+    @abstractmethod
+    async def execute(self, arguments: Dict[str, Any]) -> CallToolResult:
+        """Execute the tool with given arguments"""
+        pass
+    
+    @abstractmethod
+    def get_tool_definition(self) -> Tool:
+        """Return the tool definition for MCP server registration"""
+        pass
+    
+    def validate_required_args(self, arguments: Dict[str, Any], required: List[str]) -> Optional[str]:
+        """Validate that required arguments are present and non-empty"""
+        for arg in required:
+            if not arguments.get(arg):
+                return f"Error: {arg} is required"
+        return None
+    
+    def create_text_response(self, text: str) -> CallToolResult:
+        """Create a standard text response"""
+        return CallToolResult(
+            content=[TextContent(type="text", text=text)]
+        )
+
+
+class ToolRegistry:
+    """Registry for managing tool handlers"""
+    
+    def __init__(self):
+        self._handlers: Dict[str, BaseToolHandler] = {}
+    
+    def register(self, name: str, handler: BaseToolHandler):
+        """Register a tool handler"""
+        self._handlers[name] = handler
+        logger.debug(f"Registered tool handler: {name}")
+    
+    def get_handler(self, name: str) -> Optional[BaseToolHandler]:
+        """Get a tool handler by name"""
+        return self._handlers.get(name)
+    
+    def list_tool_names(self) -> List[str]:
+        """List all registered tool names"""
+        return list(self._handlers.keys())
+    
+    def get_tool_definitions(self) -> List[Tool]:
+        """Get all tool definitions for MCP server registration"""
+        return [handler.get_tool_definition() for handler in self._handlers.values()]
+    
+    async def execute_tool(self, name: str, arguments: Dict[str, Any]) -> CallToolResult:
+        """Execute a tool by name with error handling"""
+        try:
+            handler = self.get_handler(name)
+            if not handler:
+                return CallToolResult(
+                    content=[TextContent(type="text", text=f"Unknown tool: {name}")]
+                )
+            
+            return await handler.execute(arguments)
+        
+        except Exception as e:
+            logger.error(f"Error in tool call {name}: {e}")
+            return CallToolResult(
+                content=[TextContent(type="text", text=f"Error executing {name}: {str(e)}")]
+            )
+
+
+# Global tool registry instance
+tool_registry = ToolRegistry()


### PR DESCRIPTION
## Summary

• Refactor MCP server tool handling from monolithic if/elif chain to modular registry system
• Add BaseToolHandler abstract class with common validation and response utilities  
• Create ToolRegistry for centralized tool management
• Implement individual handler classes for each of the 9 tools
• Add syntax checking script for future CI/CD integration
• Reduce call_tool function from 170+ lines to 3 lines

## Benefits

• **Maintainability**: Adding new tools is now trivial - just create a handler class and register it
• **Separation of Concerns**: Each tool has its own focused handler class
• **Consistency**: Common validation and response patterns enforced by base class
• **Testability**: Individual handlers can be easily unit tested
• **Extensibility**: Registry pattern makes it easy to add features like tool metadata, permissions, etc.

## Test Plan

- [x] All Python files pass syntax check via check_syntax.py
- [x] Server starts successfully with new registry system
- [x] All 9 existing tools preserved with identical functionality
- [x] Tool definitions properly registered and exposed via MCP protocol
- [x] Error handling maintained through registry's execute_tool method

🤖 Generated with [Claude Code](https://claude.ai/code)